### PR TITLE
Some emulator fixes

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -2054,7 +2054,7 @@ unsigned decode_memio(u32 addr, u32 *val, unsigned type)
 
   if(
     !((M.log.trace & X86EMU_TRACE_IO) && (type == X86EMU_MEMIO_I || type == X86EMU_MEMIO_O)) &&
-    !((M.log.trace & X86EMU_TRACE_DATA) && (type == X86EMU_MEMIO_R || type == X86EMU_MEMIO_W || X86EMU_MEMIO_X))
+    !((M.log.trace & X86EMU_TRACE_DATA) && (type == X86EMU_MEMIO_R || type == X86EMU_MEMIO_W || type == X86EMU_MEMIO_X))
   ) return err;
 
   lf = LOG_FREE(&M);
@@ -2130,7 +2130,7 @@ unsigned emu_memio(x86emu_t *emu, u32 addr, u32 *val, unsigned type)
 
   if(
     !((emu->log.trace & X86EMU_TRACE_IO) && (type == X86EMU_MEMIO_I || type == X86EMU_MEMIO_O)) &&
-    !((emu->log.trace & X86EMU_TRACE_DATA) && (type == X86EMU_MEMIO_R || type == X86EMU_MEMIO_W || X86EMU_MEMIO_X))
+    !((emu->log.trace & X86EMU_TRACE_DATA) && (type == X86EMU_MEMIO_R || type == X86EMU_MEMIO_W || type == X86EMU_MEMIO_X))
   ) return err;
 
   lf = LOG_FREE(emu);

--- a/ops.c
+++ b/ops.c
@@ -3633,17 +3633,15 @@ static void x86emuOp_ret_near_IMM(u8 op1)
   u32 imm;
 
   OP_DECODE("ret ");
-  imm = MODE_DATA32 ? fetch_long() : fetch_word();
+  imm = fetch_word();
+
+  DECODE_HEX4(imm);
 
   if(MODE_DATA32) {
-    DECODE_HEX8(imm);
-
     M.x86.R_EIP = pop_long();
     M.x86.R_ESP += imm;
   }
   else {
-    DECODE_HEX4(imm);
-
     M.x86.R_EIP = pop_word();
     M.x86.R_SP += imm;
   }
@@ -3929,18 +3927,16 @@ static void x86emuOp_ret_far_IMM(u8 op1)
   u32 imm, eip;
 
   OP_DECODE("retf ");
-  imm = MODE_DATA32 ? fetch_long() : fetch_word();
+  imm = fetch_word();
+
+  DECODE_HEX4(imm);
 
   if(MODE_DATA32) {
-    DECODE_HEX8(imm);
-
     eip = pop_long();
     cs = pop_long();
     M.x86.R_ESP += imm;
   }
   else {
-    DECODE_HEX4(imm);
-
     eip = pop_word();
     cs = pop_word();
     M.x86.R_SP += imm;

--- a/prim_ops.c
+++ b/prim_ops.c
@@ -1136,7 +1136,7 @@ u8 rol_byte(u8 d, u8 s)
 		CONDITIONAL_SET_FLAG(s == 1 &&
 							 XOR2((res & 0x1) + ((res >> 6) & 0x2)),
 							 F_OF);
-	} if (s != 0) {
+	} else if (s != 0) {
 		/* set the new carry flag, Note that it is the low order
 		   bit of the result!!!                               */
 		CONDITIONAL_SET_FLAG(res & 0x1, F_CF);
@@ -1161,7 +1161,7 @@ u16 rol_word(u16 d, u8 s)
 		CONDITIONAL_SET_FLAG(s == 1 &&
 							 XOR2((res & 0x1) + ((res >> 14) & 0x2)),
 							 F_OF);
-	} if (s != 0) {
+	} else if (s != 0) {
 		/* set the new carry flag, Note that it is the low order
 		   bit of the result!!!                               */
 		CONDITIONAL_SET_FLAG(res & 0x1, F_CF);
@@ -1186,7 +1186,7 @@ u32 rol_long(u32 d, u8 s)
 		CONDITIONAL_SET_FLAG(s == 1 &&
 							 XOR2((res & 0x1) + ((res >> 30) & 0x2)),
 							 F_OF);
-	} if (s != 0) {
+	} else if (s != 0) {
 		/* set the new carry flag, Note that it is the low order
 		   bit of the result!!!                               */
 		CONDITIONAL_SET_FLAG(res & 0x1, F_CF);
@@ -2534,7 +2534,7 @@ void ins(int size)
           store_data_word_abs(M.x86.seg + R_ES_INDEX, M.x86.R_DI, fetch_io_word(M.x86.R_DX));
           break;
         case 4:
-          store_data_long_abs(M.x86.seg + R_ES_INDEX, M.x86.R_DI, fetch_io_byte(M.x86.R_DX));
+          store_data_long_abs(M.x86.seg + R_ES_INDEX, M.x86.R_DI, fetch_io_long(M.x86.R_DX));
           break;
       }
       M.x86.R_DI += inc;


### PR DESCRIPTION
1) "RET imm" instructions (0xC2, 0xCA) has 16-bit operand, regardless of MODE_DATA32.
2) Some fixed bugs after static analysis.