### PR TITLE
Small compatibility fixes for msvc compiler

### DIFF
--- a/include/x86emu.h
+++ b/include/x86emu.h
@@ -45,7 +45,7 @@
 extern "C" {            			/* Use "C" linkage when in C++ mode */
 #endif
 
-#include <inttypes.h>
+#include <stdint.h>
 
 
 /*---------------------- Macros and type definitions ----------------------*/


### PR DESCRIPTION
Some small nonspecific fixes for better compatibility with msvc compiler.

There are some problems with full compatibility:

1. `__attribute__` keyword from gcc,
2. `sys/io.h` and `in*/out*` function from there.

Simple fixes for this issues (**not for master branch**):

1. Add this code into the top of `include/x86emu.h` and `include/x86emu_int.h`:

    ```c
    #ifdef _MSC_VER
    #define __attribute__(...)
    #endif
    ```

2. Replace `#include <sys/io.h>` in `mem.c` with:

    ```c
    #ifndef _MSC_VER
    #include <sys/io.h>
    #else
    #define inb(...) 0xff
    #define inw(...) 0xffff
    #define inl(...) 0xffffffff
    #define outb(...)
    #define outw(...)
    #define outl(...)
    #endif
    ```
