### PR TITLE
Push cpuid msr callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,22 @@ and one of:
 
 Returns old function.
 
+### x86emu_set_cpuid_handler
+
+Execution hook
+
+    x86emu_cpuid_handler_t x86emu_set_cpuid_handler(x86emu_t *emu, x86emu_cpuid_handler_t handler);
+    typedef void (* x86emu_cpuid_handler_t)(x86emu_t *emu);
+
+Set a callback function that handles the CPUID instruction.
+Allows the user to use the host's CPUID or provide a custom implementation
+to emulate a specific CPU.
+
+Returns old function.
+
+There's no default implementation. Without the handler installed the programm
+will raise an #UD exception.
+
 ### x86emu_intr_raise
 
 Raise an interrupt

--- a/README.md
+++ b/README.md
@@ -272,6 +272,38 @@ Returns old function.
 There's no default implementation. Without the handler installed the programm
 will raise an #UD exception.
 
+### x86emu_set_rdmsr_handler
+
+Execution hook
+
+    x86emu_rdmsr_handler_t x86emu_set_rdmsr_handler(x86emu_t *emu, x86emu_rdmsr_handler_t handler);
+    typedef void (* x86emu_rdmsr_handler_t)(struct x86emu_s *);
+
+Set alternative callback function that handles the RDMSR instruction.
+Allows the user to use the host's MSR or provide a custom implementation
+to emulate a specific platform.
+
+Returns old function.
+
+The default callback function uses the *msr* array in the *x86emu_t* structure
+to read MSRs from and updates the *msr_perm* array.
+
+### x86emu_set_wrmsr_handler
+
+Execution hook
+
+    x86emu_wrmsr_handler_t x86emu_set_wrmsr_handler(x86emu_t *emu, x86emu_wrmsr_handler_t handler);
+    typedef void (* x86emu_wrmsr_handler_t)(struct x86emu_s *);
+
+Set alternative callback function that handles the WRMSR instruction.
+Allows the user to use the host's MSR or provide a custom implementation
+to emulate a specific platform.
+
+Returns old function.
+
+The default callback function uses the *msr* array in the *x86emu_t* structure
+to write MSRs to and updates the *msr_perm* array.
+
 ### x86emu_intr_raise
 
 Raise an interrupt

--- a/api.c
+++ b/api.c
@@ -179,6 +179,17 @@ API_SYM x86emu_code_handler_t x86emu_set_code_handler(x86emu_t *emu, x86emu_code
   return old;
 }
 
+API_SYM x86emu_cpuid_handler_t x86emu_set_cpuid_handler(x86emu_t *emu, x86emu_cpuid_handler_t handler)
+{
+  x86emu_cpuid_handler_t old = NULL;
+
+  if(emu) {
+    old = emu->cpuid;
+    emu->cpuid = handler;
+  }
+
+  return old;
+}
 
 API_SYM unsigned x86emu_read_byte(x86emu_t *emu, unsigned addr)
 {

--- a/include/x86emu.h
+++ b/include/x86emu.h
@@ -382,6 +382,8 @@ typedef unsigned (* x86emu_memio_handler_t)(struct x86emu_s *, u32 addr, u32 *va
 typedef int (* x86emu_intr_handler_t)(struct x86emu_s *, u8 num, unsigned type);
 typedef int (* x86emu_code_handler_t)(struct x86emu_s *);
 typedef void (* x86emu_cpuid_handler_t)(struct x86emu_s *);
+typedef void (* x86emu_wrmsr_handler_t)(struct x86emu_s *);
+typedef void (* x86emu_rdmsr_handler_t)(struct x86emu_s *);
 typedef void (* x86emu_flush_func_t)(struct x86emu_s *, char *buf, unsigned size);
 
 typedef struct {
@@ -491,6 +493,8 @@ typedef struct x86emu_s {
   x86emu_cpuid_handler_t cpuid;
   x86emu_memio_handler_t memio;
   x86emu_intr_handler_t intr;
+  x86emu_wrmsr_handler_t wrmsr;
+  x86emu_wrmsr_handler_t rdmsr;
   x86emu_mem_t *mem;
   struct {
     unsigned char *map;
@@ -535,6 +539,8 @@ void x86emu_set_io_perm(x86emu_t *emu, unsigned start, unsigned end, unsigned pe
 void x86emu_set_page(x86emu_t *emu, unsigned page, void *address);
 void x86emu_reset_access_stats(x86emu_t *emu);
 
+x86emu_rdmsr_handler_t x86emu_set_rdmsr_handler(x86emu_t *emu, x86emu_rdmsr_handler_t handler);
+x86emu_wrmsr_handler_t x86emu_set_wrmsr_handler(x86emu_t *emu, x86emu_wrmsr_handler_t handler);
 x86emu_cpuid_handler_t x86emu_set_cpuid_handler(x86emu_t *emu, x86emu_cpuid_handler_t handler);
 x86emu_code_handler_t x86emu_set_code_handler(x86emu_t *emu, x86emu_code_handler_t handler);
 x86emu_intr_handler_t x86emu_set_intr_handler(x86emu_t *emu, x86emu_intr_handler_t handler);

--- a/include/x86emu.h
+++ b/include/x86emu.h
@@ -304,15 +304,16 @@ typedef struct {
 #define R_REAL_TSC	msr[0x12]
 
 /* flag conditions   */
-#define FB_CF 0x0001            /* CARRY flag  */
-#define FB_PF 0x0004            /* PARITY flag */
-#define FB_AF 0x0010            /* AUX  flag   */
-#define FB_ZF 0x0040            /* ZERO flag   */
-#define FB_SF 0x0080            /* SIGN flag   */
-#define FB_TF 0x0100            /* TRAP flag   */
-#define FB_IF 0x0200            /* INTERRUPT ENABLE flag */
-#define FB_DF 0x0400            /* DIR flag    */
-#define FB_OF 0x0800            /* OVERFLOW flag */
+#define FB_CF 0x000001            /* CARRY flag  */
+#define FB_PF 0x000004            /* PARITY flag */
+#define FB_AF 0x000010            /* AUX  flag   */
+#define FB_ZF 0x000040            /* ZERO flag   */
+#define FB_SF 0x000080            /* SIGN flag   */
+#define FB_TF 0x000100            /* TRAP flag   */
+#define FB_IF 0x000200            /* INTERRUPT ENABLE flag */
+#define FB_DF 0x000400            /* DIR flag    */
+#define FB_OF 0x000800            /* OVERFLOW flag */
+#define FB_ID 0x200000            /* ID flag */
 
 /* 80286 and above always have bit#1 set */
 #define F_ALWAYS_ON  (0x0002)   /* flag bits always on */
@@ -380,6 +381,7 @@ struct x86emu_s;
 typedef unsigned (* x86emu_memio_handler_t)(struct x86emu_s *, u32 addr, u32 *val, unsigned type);
 typedef int (* x86emu_intr_handler_t)(struct x86emu_s *, u8 num, unsigned type);
 typedef int (* x86emu_code_handler_t)(struct x86emu_s *);
+typedef void (* x86emu_cpuid_handler_t)(struct x86emu_s *);
 typedef void (* x86emu_flush_func_t)(struct x86emu_s *, char *buf, unsigned size);
 
 typedef struct {
@@ -486,6 +488,7 @@ x86			- X86 registers
 typedef struct x86emu_s {
   x86emu_regs_t x86;
   x86emu_code_handler_t code_check;
+  x86emu_cpuid_handler_t cpuid;
   x86emu_memio_handler_t memio;
   x86emu_intr_handler_t intr;
   x86emu_mem_t *mem;
@@ -532,6 +535,7 @@ void x86emu_set_io_perm(x86emu_t *emu, unsigned start, unsigned end, unsigned pe
 void x86emu_set_page(x86emu_t *emu, unsigned page, void *address);
 void x86emu_reset_access_stats(x86emu_t *emu);
 
+x86emu_cpuid_handler_t x86emu_set_cpuid_handler(x86emu_t *emu, x86emu_cpuid_handler_t handler);
 x86emu_code_handler_t x86emu_set_code_handler(x86emu_t *emu, x86emu_code_handler_t handler);
 x86emu_intr_handler_t x86emu_set_intr_handler(x86emu_t *emu, x86emu_intr_handler_t handler);
 x86emu_memio_handler_t x86emu_set_memio_handler(x86emu_t *emu, x86emu_memio_handler_t handler);

--- a/ops.c
+++ b/ops.c
@@ -2386,9 +2386,15 @@ Handles opcode 0x9c
 static void x86emuOp_pushf_word(x86emu_t *emu, u8 op1)
 {
   u32 flags;
+  u32 mask = F_MSK;
+
+  if(emu->cpuid) {
+    /* Advertise CPUID support */
+    mask |= FB_ID;
+  }
 
   /* clear out *all* bits not representing flags, and turn on real bits */
-  flags = (emu->x86.R_EFLG & F_MSK) | F_ALWAYS_ON;
+  flags = (emu->x86.R_EFLG & mask) | F_ALWAYS_ON;
 
   if(MODE_DATA32) {
     OP_DECODE("pushfd");

--- a/ops2.c
+++ b/ops2.c
@@ -679,6 +679,21 @@ static void x86emuOp2_pop_FS(x86emu_t *emu, u8 op2)
   x86emu_set_seg_register(emu, emu->x86.R_FS_SEL, MODE_DATA32 ? pop_long(emu) : pop_word(emu));
 }
 
+/****************************************************************************
+REMARKS:
+Handles opcode 0x0f,0xa2
+****************************************************************************/
+static void x86emuOp2_cpuid(x86emu_t *emu, u8 op2)
+{
+  OP_DECODE("cpuid ");
+
+  if(emu->cpuid) {
+    emu->cpuid(emu);
+  }
+  else {
+    INTR_RAISE_UD(emu);
+  }
+}
 
 /****************************************************************************
 REMARKS:
@@ -1936,7 +1951,7 @@ void (*x86emu_optab2[256])(x86emu_t *emu, u8) =
 
   /*  0xa0 */ x86emuOp2_push_FS,
   /*  0xa1 */ x86emuOp2_pop_FS,
-  /*  0xa2 */ x86emuOp2_illegal_op,
+  /*  0xa2 */ x86emuOp2_cpuid,
   /*  0xa3 */ x86emuOp2_bt_R,
   /*  0xa4 */ x86emuOp2_shld_IMM,
   /*  0xa5 */ x86emuOp2_shld_CL,

--- a/ops2.c
+++ b/ops2.c
@@ -389,8 +389,9 @@ static void x86emuOp2_wrmsr(x86emu_t *emu, u8 op2)
     INTR_RAISE_UD(emu);
   }
   else {
-    emu->x86.msr[u] = ((u64) emu->x86.R_EDX << 32) + emu->x86.R_EAX;
-    emu->x86.msr_perm[u] |= X86EMU_ACC_W;
+    if(emu->wrmsr) {
+      emu->wrmsr(emu);
+    }
   }
 }
 
@@ -421,14 +422,13 @@ static void x86emuOp2_rdmsr(x86emu_t *emu, u8 op2)
   OP_DECODE("rdmsr");
 
   u = emu->x86.R_ECX;
-
   if(u >= X86EMU_MSRS) {
     INTR_RAISE_UD(emu);
   }
   else {
-    emu->x86.R_EDX = emu->x86.msr[u] >> 32;
-    emu->x86.R_EAX = emu->x86.msr[u];
-    emu->x86.msr_perm[u] |= X86EMU_ACC_R;
+    if(emu->rdmsr) {
+      emu->rdmsr(emu);
+    }
   }
 }
 


### PR DESCRIPTION
Add three new handlers to allow the user to handle rdmsr, wrmsr and cpuid as those are platform specific. The user can either redirect them to the machine currently running on or provide a custom implementation to emulate a specific platform.

The default handlers still provide the current functionality.
Superseeds PR #20 