### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq nasm
+    - name: Build
+      run: make
+    - name: Run tests
+      run: make -C test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: c
-
-before_install:
-- sudo apt-get update -qq
-- sudo apt-get install -qq nasm
-
-script:
-- make
-- make -C test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # x86 emulation library
 
-[![Build Status](https://travis-ci.org/wfeldt/libx86emu.svg?branch=master)](https://travis-ci.org/wfeldt/libx86emu)
-
 libx86emu is a small library to emulate x86 instructions. The focus here is not a complete emulation (go for qemu for this) but to cover enough for typical firmware blobs.
 
 At the moment 'regular' 32-bit instructions are covered together with basic protected mode support.


### PR DESCRIPTION
travis-ci.org is shutting down soon, which means that without intervention, the test suite will no longer be run at every commit and pull request. Since the project is hosted on GitHub already, we might as well avoid the external dependency and migrate CI to Actions.

If this is merged, disabling Travis hooks will have to be done separately in repository settings.

I left the build badge out of the README file, but an Actions-based badge is available and can be added back if desired.