### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,4 @@
-ARCH	:= $(shell uname -m)
-ifneq ($(filter i386 i486 i586 i686, $(ARCH)),)
-ARCH	:= i386
-endif
-
-ifdef LIBX86EMU_VERSION
-VERSION := $(shell echo ${LIBX86EMU_VERSION} > VERSION; cat VERSION)
-else
-GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
-VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
-endif
-GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
-BRANCH  := $(shell [ -d .git ] && git branch | perl -ne 'print $$_ if s/^\*\s*//')
-PREFIX  := libx86emu-$(VERSION)
-
-MAJOR_VERSION := $(shell cut -d . -f 1 VERSION)
-
-CC	= gcc
-CFLAGS	= -g -O2 -fPIC -fvisibility=hidden -fomit-frame-pointer -Wall
-LDFLAGS =
-
-LIBDIR = /usr/lib$(shell ldd /bin/sh | grep -q /lib64/ && echo 64)
-LIBX86	= libx86emu
-
-CFILES	= $(wildcard *.c)
-OBJS	= $(CFILES:.c=.o)
-
-LIB_NAME	= $(LIBX86).so.$(VERSION)
-LIB_SONAME	= $(LIBX86).so.$(MAJOR_VERSION)
+include config.mk
 
 .PHONY: all shared install uninstall test demo clean distclean
 
@@ -88,4 +60,3 @@ ifneq "$(MAKECMDGOALS)" "clean"
 	@$(CC) -MG -MM $(CFLAGS) $(CFILES) >$@
 -include .depend
 endif
-

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OBJS	= $(CFILES:.c=.o)
 LIB_NAME	= $(LIBX86).so.$(VERSION)
 LIB_SONAME	= $(LIBX86).so.$(MAJOR_VERSION)
 
-.PHONY: all shared install test demo clean
+.PHONY: all shared install uninstall test demo clean
 
 %.o: %.c
 	$(CC) -c $(CFLAGS) $<
@@ -49,6 +49,12 @@ install: shared
 	ln -snf $(LIB_NAME) $(DESTDIR)$(LIBDIR)/$(LIB_SONAME)
 	ln -snf $(LIB_SONAME) $(DESTDIR)$(LIBDIR)/$(LIBX86).so
 	install -m 644 -D include/x86emu.h $(DESTDIR)/usr/include/x86emu.h
+
+uninstall:
+	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_NAME)
+	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_SONAME)
+	rm -f $(DESTDIR)$(LIBDIR)/$(LIBX86).so
+	rm -f $(DESTDIR)/usr/include/x86emu.h
 
 $(LIB_NAME): .depend $(OBJS)
 	$(CC) -shared -Wl,-soname,$(LIB_SONAME) $(OBJS) -o $(LIB_NAME) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@ ifneq ($(filter i386 i486 i586 i686, $(ARCH)),)
 ARCH	:= i386
 endif
 
+ifdef LIBX86EMU_VERSION
+VERSION := $(shell echo ${LIBX86EMU_VERSION} > VERSION; cat VERSION)
+else
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
-GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
 VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
+endif
+GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
 BRANCH  := $(shell [ -d .git ] && git branch | perl -ne 'print $$_ if s/^\*\s*//')
 PREFIX  := libx86emu-$(VERSION)
 
-MAJOR_VERSION := $(shell $(GIT2LOG) --version VERSION ; cut -d . -f 1 VERSION)
+MAJOR_VERSION := $(shell cut -d . -f 1 VERSION)
 
 CC	= gcc
 CFLAGS	= -g -O2 -fPIC -fvisibility=hidden -fomit-frame-pointer -Wall
@@ -31,8 +35,12 @@ LIB_SONAME	= $(LIBX86).so.$(MAJOR_VERSION)
 
 all: changelog shared
 
+ifdef LIBX86EMU_VERSION
+changelog: ;
+else
 changelog: $(GITDEPS)
 	$(GIT2LOG) --changelog changelog
+endif
 
 shared: $(LIB_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OBJS	= $(CFILES:.c=.o)
 LIB_NAME	= $(LIBX86).so.$(VERSION)
 LIB_SONAME	= $(LIBX86).so.$(MAJOR_VERSION)
 
-.PHONY: all shared install uninstall test demo clean
+.PHONY: all shared install uninstall test demo clean distclean
 
 %.o: %.c
 	$(CC) -c $(CFLAGS) $<
@@ -79,6 +79,9 @@ clean:
 	make -C demo clean
 	rm -f *.o *~ include/*~ *.so.* *.so .depend
 	rm -rf package
+
+distclean: clean
+	rm -f VERSION changelog
 
 ifneq "$(MAKECMDGOALS)" "clean"
 .depend: $(CFILES)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include config.mk
 .PHONY: all shared install uninstall test demo clean distclean
 
 %.o: %.c
-	$(CC) -c $(CFLAGS) $<
+	$(CC) -c $(ALL_CFLAGS) $<
 
 all: changelog shared
 
@@ -20,35 +20,36 @@ install: shared
 	install -D $(LIB_NAME) $(DESTDIR)$(LIBDIR)/$(LIB_NAME)
 	ln -snf $(LIB_NAME) $(DESTDIR)$(LIBDIR)/$(LIB_SONAME)
 	ln -snf $(LIB_SONAME) $(DESTDIR)$(LIBDIR)/$(LIBX86).so
-	install -m 644 -D include/x86emu.h $(DESTDIR)/usr/include/x86emu.h
+	install -m 644 -D include/x86emu.h $(DESTDIR)$(INCLUDEDIR)/x86emu.h
 
 uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_NAME)
 	rm -f $(DESTDIR)$(LIBDIR)/$(LIB_SONAME)
 	rm -f $(DESTDIR)$(LIBDIR)/$(LIBX86).so
-	rm -f $(DESTDIR)/usr/include/x86emu.h
+	rm -f $(DESTDIR)$(INCLUDEDIR)/x86emu.h
+	rm -f $(DESTDIR)$(OLDINCLUDEDIR)/x86emu.h
 
 $(LIB_NAME): .depend $(OBJS)
-	$(CC) -shared -Wl,-soname,$(LIB_SONAME) $(OBJS) -o $(LIB_NAME) $(LDFLAGS)
+	$(CC) -shared -Wl,-soname,$(LIB_SONAME) $(ALL_CFLAGS) $(OBJS) -o $(LIB_NAME) $(LDFLAGS)
 	@ln -snf $(LIB_NAME) $(LIB_SONAME)
 	@ln -snf $(LIB_SONAME) $(LIBX86).so
 
 test:
-	make -C test
+	$(MAKE) -C test
 
 demo:
-	make -C demo
+	$(MAKE) -C demo
 
 archive: changelog
 	@if [ ! -d .git ] ; then echo no git repo ; false ; fi
 	mkdir -p package
-	git archive --prefix=$(PREFIX)/ $(BRANCH) > package/$(PREFIX).tar
-	tar -r -f package/$(PREFIX).tar --mode=0664 --owner=root --group=root --mtime="`git show -s --format=%ci`" --transform='s:^:$(PREFIX)/:' VERSION changelog
-	xz -f package/$(PREFIX).tar
+	git archive --prefix=$(ARCHIVE_PREFIX)/ $(BRANCH) > package/$(ARCHIVE_PREFIX).tar
+	tar -r -f package/$(ARCHIVE_PREFIX).tar --mode=0664 --owner=root --group=root --mtime="`git show -s --format=%ci`" --transform='s:^:$(ARCHIVE_PREFIX)/:' VERSION changelog
+	xz -f package/$(ARCHIVE_PREFIX).tar
 
 clean:
-	make -C test clean
-	make -C demo clean
+	$(MAKE) -C test clean
+	$(MAKE) -C demo clean
 	rm -f *.o *~ include/*~ *.so.* *.so .depend
 	rm -rf package
 
@@ -57,6 +58,6 @@ distclean: clean
 
 ifneq "$(MAKECMDGOALS)" "clean"
 .depend: $(CFILES)
-	@$(CC) -MG -MM $(CFLAGS) $(CFILES) >$@
+	@$(CC) -MG -MM $(ALL_CFLAGS) $(CFILES) >$@
 -include .depend
 endif

--- a/README.md
+++ b/README.md
@@ -391,6 +391,14 @@ Reset memory access stats. See `x86emu_reset_access_stats()`.
 
 To build, simply run `make`. Install with `make install`.
 
+The `LIBX86EMU_VERSION` flag should be used if libx86emu isn't being compiled in a git repository
+(e.g. when compiling from release archive). For example, compilation and installation of the version
+3.2 form a release archive should look like this:
+```shell
+make LIBX86EMU_VERSION=3.2
+sudo make install LIBX86EMU_VERSION=3.2
+```
+
 Basically every new commit into the master branch of the repository will be auto-submitted
 to all current SUSE products. No further action is needed except accepting the pull request.
 

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,29 @@
+ARCH	:= $(shell uname -m)
+ifneq ($(filter i386 i486 i586 i686, $(ARCH)),)
+ARCH	:= i386
+endif
+
+ifdef LIBX86EMU_VERSION
+VERSION := $(shell echo ${LIBX86EMU_VERSION} > VERSION; cat VERSION)
+else
+GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
+VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
+endif
+GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
+BRANCH  := $(shell [ -d .git ] && git branch | perl -ne 'print $$_ if s/^\*\s*//')
+PREFIX  := libx86emu-$(VERSION)
+
+MAJOR_VERSION := $(shell cut -d . -f 1 VERSION)
+
+CC	= gcc
+CFLAGS	= -g -O2 -fPIC -fvisibility=hidden -fomit-frame-pointer -Wall
+LDFLAGS =
+
+LIBDIR = /usr/lib$(shell ldd /bin/sh | grep -q /lib64/ && echo 64)
+LIBX86	= libx86emu
+
+CFILES	= $(wildcard *.c)
+OBJS	= $(CFILES:.c=.o)
+
+LIB_NAME	= $(LIBX86).so.$(VERSION)
+LIB_SONAME	= $(LIBX86).so.$(MAJOR_VERSION)

--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,4 @@
+SHELL = /bin/sh
 ARCH	:= $(shell uname -m)
 ifneq ($(filter i386 i486 i586 i686, $(ARCH)),)
 ARCH	:= i386
@@ -11,15 +12,25 @@ VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
 endif
 GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
 BRANCH  := $(shell [ -d .git ] && git branch | perl -ne 'print $$_ if s/^\*\s*//')
-PREFIX  := libx86emu-$(VERSION)
+ARCHIVE_PREFIX  := libx86emu-$(VERSION)
+
+PREFIX ?= /usr/local
+EXEC_PREFIX ?= $(PREFIX)
+ifeq "$(ARCH)" "x86_64"
+LIBDIR ?= $(EXEC_PREFIX)/lib64
+else
+LIBDIR ?= $(EXEC_PREFIX)/lib
+endif
+INCLUDEDIR ?= $(PREFIX)/include
 
 MAJOR_VERSION := $(shell cut -d . -f 1 VERSION)
 
-CC	= gcc
-CFLAGS	= -g -O2 -fPIC -fvisibility=hidden -fomit-frame-pointer -Wall
-LDFLAGS =
+CC	?= gcc
+CFLAGS	?= -g -O2 -Wall -fomit-frame-pointer
+ALL_CFLAGS	= -fPIC -fvisibility=hidden $(CFLAGS)
 
-LIBDIR = /usr/lib$(shell ldd /bin/sh | grep -q /lib64/ && echo 64)
+export CC CFLAGS ARCH
+
 LIBX86	= libx86emu
 
 CFILES	= $(wildcard *.c)

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,5 +1,6 @@
-CC         = gcc
-CFLAGS     = -g -Wall -fomit-frame-pointer -O2
+SHELL      = /bin/sh
+CC         ?= gcc
+CFLAGS     ?= -g -Wall -fomit-frame-pointer -O2
 
 .PHONY: clean
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
-CC         = gcc
-CFLAGS     = -g -Wall -fomit-frame-pointer -O2
-LDFLAGS    =
+SHELL      = /bin/sh
+CC         ?= gcc
+CFLAGS     ?= -g -Wall -fomit-frame-pointer -O2
 TST_FILES  = $(sort $(wildcard *.tst))
 INIT_FILES = $(addsuffix .init,$(basename $(wildcard *.tst)))
 RES_FILES  = $(sort $(addsuffix .result,$(basename $(wildcard *.tst))))


### PR DESCRIPTION
These changes were inspired by `hwinfo`s Makefile and by the [GNU make manual](https://www.gnu.org/software/make/manual/make.html#Makefile-Conventions).

The current version detection system and the changelog are fully dependent on git. This complicates building from release archives. One of my commits adds the `LIBX86EMU_VERSION` variable that makes things simpler, but this is not a good solution in my opinion. Another solution to this problem is to add a `VERSION` file that would be incremented on every release. This wouldn't change the logic that much since Makefile already uses `VERSION`.

And while we're here, I'll ask some questions: Is the `$(ARCH)` variable used for anything in the current version of `libx86emu`s Makefile and do you have any specific reason to use `/usr/lib64` instead of `/usr/lib`?