### PR TITLE
fix test suite for 32-bit architectures

### DIFF
--- a/test/prepare_test
+++ b/test/prepare_test
@@ -414,7 +414,9 @@ sub nr
   $n = ((int rand 0x1000000) & 0xffff00) << 8;
   $n += int((rand 0x1000000) / 11);
 
-  return $n;
+  # Limit the result to a 32 bit number but avoid '&' to ensure it works
+  # with 32 bit perl.
+  return $n % 2 ** 32;
 }
 
 


### PR DESCRIPTION
## Problem

- see https://github.com/wfeldt/libx86emu/issues/38

Some tests failed when run on i686.

The cause was that the random number generation used for preparing the test data didn't work correctly on 32 bit architectures and could produce differing results when a 32 bit overflow occcured in the internal calculation.

Ensure the the random number function generates 32 bit numbers but avoid `& 0xffffffff` to cut the return value down to 32 bit as this may trigger an integer overflow. Instead divide by `2^32` as this calculation is done with floating point numbers.

To illustrate the issue:

- 32 bit perl:
```
# perl -e '$x = 5000000000; printf "$x 0x%x\n", $x'
5000000000 0xffffffff
```

- 64 bit perl:
```
# perl -e '$x = 5000000000; printf "$x 0x%x\n", $x'
5000000000 0x12a05f200
```