### PR TITLE
prim_ops: fix some indentation

### DIFF
--- a/prim_ops.c
+++ b/prim_ops.c
@@ -1776,9 +1776,10 @@ u16 sbb_word(x86emu_t *emu, u16 d, u16 s)
     register u32 bc;
 
 	if (ACCESS_FLAG(F_CF))
-        res = d - s - 1;
-    else
-        res = d - s;
+		res = d - s - 1;
+	else
+		res = d - s;
+
 	CONDITIONAL_SET_FLAG(res & 0x8000, F_SF);
 	CONDITIONAL_SET_FLAG((res & 0xffff) == 0, F_ZF);
 	CONDITIONAL_SET_FLAG(PARITY(res & 0xff), F_PF);
@@ -1801,9 +1802,9 @@ u32 sbb_long(x86emu_t *emu, u32 d, u32 s)
 	register u32 bc;
 
 	if (ACCESS_FLAG(F_CF))
-        res = d - s - 1;
-    else
-        res = d - s;
+		res = d - s - 1;
+	else
+		res = d - s;
 	CONDITIONAL_SET_FLAG(res & 0x80000000, F_SF);
 	CONDITIONAL_SET_FLAG((res & 0xffffffff) == 0, F_ZF);
 	CONDITIONAL_SET_FLAG(PARITY(res & 0xff), F_PF);


### PR DESCRIPTION
It upsets gcc's -Wmisleading-indentation:

```
  prim_ops.c: In function ‘sbb_word’:
  prim_ops.c:1780:5: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
   1780 |     else
        |     ^~~~
  In file included from prim_ops.c:99:
  include/x86emu_int.h:76:3: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
     76 |   if(COND) SET_FLAG(FLAG); else CLEAR_FLAG(FLAG)
        |   ^~
  prim_ops.c:1782:9: note: in expansion of macro ‘CONDITIONAL_SET_FLAG’
   1782 |         CONDITIONAL_SET_FLAG(res & 0x8000, F_SF);
        |         ^~~~~~~~~~~~~~~~~~~~
  prim_ops.c: In function ‘sbb_long’:
  prim_ops.c:1805:5: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
   1805 |     else
        |     ^~~~
  include/x86emu_int.h:76:3: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
     76 |   if(COND) SET_FLAG(FLAG); else CLEAR_FLAG(FLAG)
        |   ^~
  prim_ops.c:1807:9: note: in expansion of macro ‘CONDITIONAL_SET_FLAG’
   1807 |         CONDITIONAL_SET_FLAG(res & 0x80000000, F_SF);
        |         ^~~~~~~~~~~~~~~~~~~~
```