### PR TITLE
fix building on non-x86 architectures

### DIFF
--- a/mem.c
+++ b/mem.c
@@ -35,6 +35,14 @@
 #include "include/x86emu_int.h"
 #if defined(__i386__) || defined (__x86_64__)
 #include <sys/io.h>
+#else
+/* define some dummy macros; see also WITH_IOPL in x86emu_int.h */
+#define inb(addr) 0xff
+#define inw(addr) 0xffff
+#define inl(addr) 0xffffffff
+#define outb(val, addr)
+#define outw(val, addr)
+#define outl(val, addr)
 #endif
 
 #define PERM16(a)	((a) + ((a) << 8))


### PR DESCRIPTION
## Task

On non-x86 architectures io-functions like `inb()` or `outb()` are not necessarily available (and not used anyway).

See https://github.com/wfeldt/libx86emu/issues/43